### PR TITLE
close the communication threads when `GUIView.dispose` gets called

### DIFF
--- a/test/core/src/temalab/communicator/MainCommunicator.java
+++ b/test/core/src/temalab/communicator/MainCommunicator.java
@@ -12,6 +12,7 @@ public class MainCommunicator{
     private boolean pause;
     private List<Communicator> communictors;
     private boolean runCommThread;
+    private Thread shutdownHook;
 
     public MainCommunicator(MainModel mm) {
         communictors = new ArrayList<>();
@@ -50,9 +51,16 @@ public class MainCommunicator{
 			}
 		};
 		commThread.start();
+		shutdownHook = new Thread(this::stop);
+		Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
     public void stop() {
+        synchronized(shutdownHook) {
+            if (!Runtime.getRuntime().removeShutdownHook(shutdownHook)) {
+                return;
+            }
+        }
         runCommThread = false;
         commThread.interrupt();
         try {

--- a/test/core/src/temalab/gui/view/GUIView.java
+++ b/test/core/src/temalab/gui/view/GUIView.java
@@ -40,6 +40,7 @@ public class GUIView extends ApplicationAdapter implements MainModelListener{
 	private Map<Team, TeamView> teamViews;
 	private MainModel mm;
 	private MainCommunicator mc;
+	private Thread shutdownHook;
 
 	public void init(MainModel mm, MainCommunicator mc, float sizingFactor, boolean steppable) {
 		universalDistanceConstant = sizingFactor;
@@ -68,6 +69,8 @@ public class GUIView extends ApplicationAdapter implements MainModelListener{
 		controlPointViews = new HashMap<>();
 		teamViews = new HashMap<>();
 		mm.addListener(this);
+		shutdownHook = new Thread(this::dispose);
+		Runtime.getRuntime().addShutdownHook(shutdownHook);
 	}
 
 	@Override
@@ -127,6 +130,11 @@ public class GUIView extends ApplicationAdapter implements MainModelListener{
 
 	@Override
 	public void dispose() {
+		synchronized(shutdownHook) {
+			if (!Runtime.getRuntime().removeShutdownHook(shutdownHook)) {
+				return;
+			}
+		}
 		shapeRenderer.dispose();
 		batch.dispose();
 		font.dispose();

--- a/test/core/src/temalab/gui/view/GUIView.java
+++ b/test/core/src/temalab/gui/view/GUIView.java
@@ -130,6 +130,7 @@ public class GUIView extends ApplicationAdapter implements MainModelListener{
 		shapeRenderer.dispose();
 		batch.dispose();
 		font.dispose();
+		mc.stop();
 		System.exit(0);
 	}
 	


### PR DESCRIPTION
Ez a PR módosítja a `MainCommunicator` főszálát és `stop` metódusát, hogy a metódus szóljon a főszálnak amikor le kell állnia. A metódust eddig semmi nem hívta meg, most már a `GUIView` `dispose` metódusa hívja meg.